### PR TITLE
Replaced 'set' commands with 'option' and removed comment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,14 @@ set(CMAKE_CXX_STANDARD 17)
 ##########################################################
 # User configurable options of the template
 ##########################################################
-# Note: symbols like WARNINGS_AS_ERRORS in configuration are intentionally variables
-# and not CMake options --using options creates too much problem for students.
 
 #! It is a good practice to set "WARNINGS_AS_ERRORS" ON,
 #  but sometimes it creates too much trouble, so default is OFF.
-set(WARNINGS_AS_ERRORS OFF)
+option(WARNINGS_AS_ERRORS 
+	"Promotes compile-time warnings to errors that prevent the successfull builds" OFF)
 
 #! Always use PVS Studio while developing. 
-set(ENABLE_PVS_STUDIO OFF)
+option(ENABLE_PVS_STUDIO "PVS Studio code analyser" OFF)
 
 #! Select appropriate sanitizers.
 #  Definitely enable sanitizers while developing.
@@ -30,22 +29,24 @@ set(ENABLE_PVS_STUDIO OFF)
 
 #! UndefinedBehaviorSanitizer (UBSan)
 #  Info: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
-set(ENABLE_UBSan OFF)
+option(ENABLE_UBSan "UndefinedBehaviorSanitizer" OFF)
+
 #! AddressSanitizer -- detects use after free or after scope exit,
 #  memory overflows and leaks.  
 #  Info: https://github.com/google/sanitizers/wiki/AddressSanitizer
-set(ENABLE_ASAN OFF)
+option(ENABLE_ASAN "AddressSanitizer" OFF)
+
 #! ThreadSanitizer -- detects data races.
-set(ENABLE_TSan OFF)
+option(ENABLE_TSan "ThreadSanitizer" OFF)
+
 #! MemorySanitizer detects uninitialized memory reads 
 #  Info: https://github.com/google/sanitizers/wiki/MemorySanitizer
-set(ENABLE_MSAN OFF)
+option(ENABLE_MSAN "ThreadSanitizer" OFF)
 
 
 #! Be default -- build release version if not specified otherwise.
-if (NOT CMAKE_BUILD_TYPE)
-	set(CMAKE_BUILD_TYPE Release)
-endif ()
+option(CMAKE_BUILD_TYPE
+	 "Select the build optimization type Debug/RelseaseWithDebugInfo/Release" Release)
 
 # Warnings as errors should be imported here -- do not move this line
 include(cmake/CompilerWarnings.cmake)


### PR DESCRIPTION
Noted that we are just setting compile options with `set(name val)` while it feels strange for me not to use `option(name "comment" val)`

This simplifies the inspection and visualization of compile-time params:
gui-CMake before:
![image](https://user-images.githubusercontent.com/17781705/220122878-d1277a5b-eee2-4ed3-95c7-35dd00a9e1e1.png)

gui-CMake after:
![image](https://user-images.githubusercontent.com/17781705/220122901-8af73cbe-512b-45bb-89a3-6c9cc89e5a84.png)

P.S. I saw that comment about this move being intentional, but what are the reasons?