### PR TITLE
Add paths-ignore patterns to GitHub workflow

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -4,10 +4,18 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'data/**'
+      - '**.md'
+      - '**.py'
+      - '**.sh'
+      - '**.txt'
+      - '!**/CMakeLists.txt'
+      - '!dependencies/apt.txt'
   workflow_dispatch:
   pull_request:
-    branches: 
-    - master 
+    branches:
+    - master
     
 concurrency:
   group: ci-${{ github.actor }}


### PR DESCRIPTION
This pull request adds paths-ignore patterns to the GitHub workflow for the project. The paths-ignore patterns are used to specify which files and directories should be ignored by the build process and not included in the final build artifacts.

The following patterns have been added to the paths-ignore list:
* `data/**`
* `**.md`
* `**.py`
* `**.sh`
* `**.txt`
* `!**/CMakeLists.txt` - prevent ignoring CMakeLists.txt anywhere in the repository
* `!dependencies/apt.txt` - prevent ignoring dependencies used by the workflow

These patterns were chosen based on the project's build process and the files and directories needed for the build process. The new patterns should help ensure that only the necessary files are included in the build artifacts and that the build process is as efficient and reliable as possible.

@Myralllka Please review this pull request and let me know your questions or concerns.